### PR TITLE
Update values.yaml

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -1,6 +1,6 @@
 owner-info:
   support-group: foundation
-  service: baremetal
+  service: hwconsole-exporter
   maintainers:
     - Stefan Hipfel
     - Bernd Kuespert


### PR DESCRIPTION
Colleagues are getting confused in the alert monitoring about baremetal alerts from outdated images. Therefore, it is better to not call the service baremetal.